### PR TITLE
zmeny bwfoto 1-22

### DIFF
--- a/app/FrontModule/components/Menu/BWfoto_Fixed_Homepage.latte
+++ b/app/FrontModule/components/Menu/BWfoto_Fixed_Homepage.latte
@@ -26,7 +26,7 @@
 
     {if $iterator->isOdd()}
     <div n:class="'col d-flex', $iterator->counter != 3 ? 'flex-column justify-content-between' : 'flex-column-reverse justify-content-around'">
-      {include #figure node => $node, main_class => 'h-75', avatar => $avatar, if_part => $iterator->counter != 3}
+      {include #figure node => $node, avatar => $avatar, if_part => $iterator->counter != 3}
     {else}
       {include #part-small node => $node, main_class => 'd-flex flex-column justify-content-center h-25', is_bolder => $node->id == 5}
     </div>
@@ -43,15 +43,15 @@
     
     {if $k < 3}
       {first}<div class="col-md d-flex flex-column justify-content-between">{/first}
-        {include #figure node => $node, main_class => $k == 2 ? 'mb-3 mb-md-0' : null, avatar => $avatar, if_part => $k == 1}
+        {include #figure node => $node, avatar => $avatar, if_part => $k == 1}
       {if $k == 2}</div>{/if}
     {else}
       {if $k == 3}
       <div class="col-md d-flex flex-column justify-content-between">
-        {include #figure node => $node, main_class => 'h-50', avatar => $avatar, if_part => true}
-        <figure class="d-flex flex-column justify-content-between h-50">
+        {include #figure node => $node, avatar => $avatar, if_part => true}
+        <figure class="d-flex flex-column justify-content-between">
       {else}  
-        {include #part-small node => $node, is_bolder => $k == 5}
+        {include #part-small node => $node, main_class => 'h-25', is_bolder => $k == 5}
       {/if}
       {if $k == 6}
         </figure>

--- a/app/FrontModule/components/Menu/BWfoto_foto_section.latte
+++ b/app/FrontModule/components/Menu/BWfoto_foto_section.latte
@@ -1,7 +1,7 @@
 {if isset($startNode) && count($startNode->nodes)}
   {foreach $startNode->nodes as $node}
     {var $avatar = strlen($nastav['avatar']) && isset($node->avatar) ? $nastav['avatar'].$node->avatar : FALSE}
-    <div class="col-12 col-md-4 col-lg-3 album">
+    <div class="col-12 col-sm-6 col-md-4 col-xxl-3 album">
       <a href="{$node->link}" title="{$node->name}">
         <img n:if="$avatar && is_file($avatar)  && ($nastav['article_avatar_view_in'] & 1)"
              src="{$basePath}/{$avatar}" alt="{$node->name}" class="img-responsive img-square"/>

--- a/app/assets/front/css/bwfoto.css
+++ b/app/assets/front/css/bwfoto.css
@@ -65,7 +65,10 @@ nav .navbar-brand{
 }
 nav.shrink {
  height: auto;
-	background-color: rgba(250,250,250,0.90) !important;
+	/*background-color: rgba(250,250,250,0.90) !important;*/
+}
+#navbarSupportedContent.hidecont{
+	display: none !important;
 }
 .navbar-brand img{
 	margin: 1% 0;
@@ -112,12 +115,13 @@ nav .form-control {
 	display: none;
 }
 #webParts-md{
-		display: block;
+		display: flex;
 		margin: 0 auto 2rem auto;
+		flex: 1 1 auto;
 	}
 	#webParts-md figure{
 		position: relative;
-		flex-grow: 1;
+		height: 40vh;
 	}
 	#webParts-md figcaption{
 		position: absolute;
@@ -125,7 +129,8 @@ nav .form-control {
 	}
 	#webParts-md h2{
 		font-size: 1.2rem;
-			transition: font-size 0.3s;
+		transition: font-size 0.3s;
+		margin: 0;
 	}
 	#webParts-md figure:hover figcaption h2{
 		font-size: 1.3rem;
@@ -137,22 +142,19 @@ nav .form-control {
 #webParts .row, #webParts-md .row{
 		margin-left: 0;
 	}
- /*#webParts-md .flex-column figure:nth-child(2){
-		margin-bottom: 0;
-	}
-#webParts-md .flex-column figure:nth-child(2) figcaption{
-			top: 0px;
-	} */
-	#webParts-md figure img {
+	#webParts-md figure .img-fluid {
 			width: 100%;
-			height: 100%;
+		height: 100%;
 			object-fit: cover;
 			object-position: center;
 	}
 	#webParts-md .part-small {
-			background-color: #996600;
+		background-color: #996600;
 		padding: 1rem;
 		margin-top: .5rem;
+	}
+#webParts-md .part-small:first-child {
+		margin: 0;
 	}
 #webAlbums
 {
@@ -161,11 +163,11 @@ nav .form-control {
 #webAlbums .album
 {
 	text-align: center;
-	margin: 0;
+	margin: 1rem 0 0 0;
 }
 #webAlbums h3{
 	color: white;
-	margin: .5em 0 1.5em 0;
+	margin: .5em 0 0 0;
 }
 #webAlbums h3:hover{
 	color: #b80;
@@ -228,6 +230,7 @@ nav .form-control {
 /* footer */
 footer{
 	border-top: 2px solid #000;
+	margin-top: 2rem;
 }
 footer .nav ul{
  border-bottom: 1px solid #777;
@@ -270,6 +273,9 @@ footer .pv-footer a{
 	}
 	#webAlbums h3{
 		font-size: 1.5rem;
+	}
+	#webParts-md figure{
+		height: 45vh;
 	}
 	
 	/* male nahlady mriezka */
@@ -343,6 +349,8 @@ footer .pv-footer a{
 	}
 	#webParts figure{
 		position: relative;
+		flex-grow: 1;
+		height: 45vh;
 	}
 	#webParts figcaption{
 		position: absolute;

--- a/app/assets/front/css/vue_fotogalery.css
+++ b/app/assets/front/css/vue_fotogalery.css
@@ -169,7 +169,8 @@
 	text-align: center;
 }
 .lightbox-img .my-img-content {
-    width: 86%;
+    width: 88%;
+	margin: 0 auto;
 }
 .lightbox-img .arrows-overlay {
     position: absolute;
@@ -195,7 +196,7 @@
 }
 .lightbox-img .arrows-l > a, .lightbox-img .arrows-r > a{
     text-decoration: none;
-    padding: 0 1rem;
+    padding: 0;
 }
 .lightbox-img .arrows-r > a {
     display: inline-block;

--- a/app/assets/front/js/nav-shrink.js
+++ b/app/assets/front/js/nav-shrink.js
@@ -16,19 +16,23 @@
 document.addEventListener('DOMContentLoaded', function(){
   // Pre male rozlisenia
   var topNav = document.getElementById('topNav');
+  var contentNav = document.getElementById('navbarSupportedContent');
   if (document.body.scrollTop > 80 || document.documentElement.scrollTop > 80) {
-    topNav.classList.add('shrink');
+	topNav.classList.add('shrink');
+	contentNav.classList.add('hidecont');
   } else {
     topNav.classList.remove('shrink');
+	contentNav.classList.remove('hidecont');
   }
   
   // Pre vacsie rozlisenia
   window.onscroll = function() {
-    var topNav = document.getElementById('topNav');
     if (document.body.scrollTop > 80 || document.documentElement.scrollTop > 80) {
-      topNav.classList.add('shrink');
+	    topNav.classList.add('shrink');
+		contentNav.classList.add('hidecont');
 		} else {
-      topNav.classList.remove('shrink');
+    	topNav.classList.remove('shrink');
+		contentNav.classList.remove('hidecont');
 		}
   };
 //  document.getElementById("topMenuButton").onclick = function(){

--- a/app/assets/front/js/vue/components/Fotogalery.vue
+++ b/app/assets/front/js/vue/components/Fotogalery.vue
@@ -125,7 +125,7 @@ export default {
     </h4>
   </div>
   <div class="row">
-    <div class="d-none d-sm-inline-block col-sm-8 detail" ref="imgDetail" id="imgDetail">
+    <div class="d-none d-sm-flex justify-content-center col-sm-8 detail" ref="imgDetail" id="imgDetail">
       <div id="squarePlace" v-bind:style="{height: square + 'px', width: square + 'px'}">
         <a  v-if="myatt[id].type == 'menu'"
             :href="myatt[id].web_name" 
@@ -230,7 +230,7 @@ export default {
         <div class="go-to-hight"
             @click.prevent="openmodal2">
         </div>
-        <div class="arrows-r"
+        <div class="arrows-r flex-row-reverse"
             @click="after">
           <a href="#" class="text-light"
               :title="text_after">&#10095;


### PR DESCRIPTION
- odstranene pozadie v zmensenom menu - trieda shrink v bwfoto.css
- skrytie horneho menu po rolovani namiesto zmensenia sa horne polozky menu a vyhladavacie pole skryju - pridana trieda hidecont v bwfoto.css a upraveny navshrink.js POZNAMKA: nevedel som spravit to aby sa tlacidlo hamburger zobrazovalo ked sa skryju polozky horneho menu. Peto mozes sa na to pozriet? Asi ti zavolam a vysvetlim
- zobrazovanie iba troch nahladov v kat. 2 cize nahlady albumov. 4 vedla seba sa zobrazia az od velkosti xxl - upraveny subor BWfoto_foto_section.latte
- upravena medzera medzi popisom a nadpisom albumu, odsadeny cely album tak aby bol nadpis (ktory je pod obrazkom blizsie k tomu nahladu kde patri)  - v bwfoto.css upravene: #webAlbums .album, #webAlbums h3, footer
- upravene nahlady na titulnej strane, uroven 1 - nahlady pri zmene sirky neboli rovnake (Juraj vie :)) - zmene viacere pravidla v bwfoto.css nama v pravidlach #webParts-md a webParts. Zmenena aj sablona BWfoto_fixed_homepage.latte
- velky nahlad v urovni 3 posunuty vo svojom priestore na stred aby nebol tak velmi vzdialeny od malych nahladov - upravene v sablone Fotogalery.vue
- opraveny problem so sipkou v urovni 4 na mensich zobrazeniach - upravy vo vue-fotogallery.css niekde v pravidlach lightbox-img a tiez uprava vo Fotogalery.vue
